### PR TITLE
Bugfix in getOffset: return offset without loading

### DIFF
--- a/code/+stitchit/+tools/getOffset.m
+++ b/code/+stitchit/+tools/getOffset.m
@@ -100,6 +100,7 @@ switch offsetType
         if m>0
             m=0;
         end
+        offset.(offsetType) = m;
     case 'scanimage'
             % Find the first image of that acquisition (not assuming that 1 is
     % first)
@@ -117,9 +118,12 @@ switch offsetType
 
     firstImInfo = imfinfo(firstTiff);
     firstSI=stitchit.tools.parse_si_header(firstImInfo(1),'Software'); % Parse the ScanImage TIFF header
-
+    offset = single(firstSI.channelOffset);
+    offset.(offsetType) = offset(chan);
 end
 
 save(offsetFileName, 'offset');
+% get value to return
+offsetValue = offset.(offsetType);
 
 

--- a/code/+stitchit/+tools/getOffset.m
+++ b/code/+stitchit/+tools/getOffset.m
@@ -118,8 +118,8 @@ switch offsetType
 
     firstImInfo = imfinfo(firstTiff);
     firstSI=stitchit.tools.parse_si_header(firstImInfo(1),'Software'); % Parse the ScanImage TIFF header
-    offset = single(firstSI.channelOffset);
-    offset.(offsetType) = offset(chan);
+    siOffset = single(firstSI.channelOffset);
+    offset.(offsetType) = siOffset(chan);
 end
 
 save(offsetFileName, 'offset');


### PR DESCRIPTION
First call to getOffset was creating the offset file but not returning the offset. Also try to save the other 2 types of offsets (but not tested).

If I'm not mistaking this hack has disappeard:
```
        % The multiplication by doSubtractOffset is a hacky fix for a scanimage bug that happens 
        % when acquiring linear scanner data with an FPGA that has the PMTs set to inverted. This causes the 
        % offset to be th opposite sign, which messes up low values in our images. 
        % So if the mode and offset are of different signs for linear scanner data we flip
        % the sign of the offset. Ideally this hacky mess is temporary (TODO)
        tOffset = offset(channel) * doSubtractOffset; 
        im = uint16(single(im) - tOffset);
```

It can be reintroduced in `getOffset` or in `tileLoad`. If `doSubtractOffset` can be negative, L271 of `tileLoad` might need to be updated.