### PR TITLE
Make temporary file name user dependent

### DIFF
--- a/code/processDuringAcquistion/startBackgroundWebPreview.m
+++ b/code/processDuringAcquistion/startBackgroundWebPreview.m
@@ -11,8 +11,9 @@ function startBackgroundWebPreview(chanToPlot,config)
     % The script file name we will build to run the background task
     params = readMetaData2Stitchit;
     micName = strrep(params.System.ID,' ','_');
-    pathToBSfile = fullfile(tempdir,['webPreviewBootstrap_',micName,'.m']);
-    logFilePath = fullfile(tempdir,['webPreviewLogFile_',micName]);
+    username = getenv('username');
+    pathToBSfile = fullfile(tempdir,['webPreviewBootstrap_', username, '_', ,micName,'.m']);
+    logFilePath = fullfile(tempdir,['webPreviewLogFile_', username, '_', micName]);
     
     % Before proceeding, let's kill any currently running background web previews
     PIDs=stitchit.tools.findProcesses(pathToBSfile);


### PR DESCRIPTION
On machines with strict user permissions, one cannot overwrite the temp file created by somebody else. Make sure that the username is in the file name to avoid conflicts.